### PR TITLE
fix: 생협 크롤링 로직 변경

### DIFF
--- a/menu_crawler.py
+++ b/menu_crawler.py
@@ -532,6 +532,6 @@ def print_meals(meals):
     print("total #:", len(meals))
 
 
-crawler = SnucoRestaurantCrawler()
-asyncio.run(crawler.run(date=datetime.date(2022, 10, 26)))
-print_meals(crawler.meals)
+# crawler = SnucoRestaurantCrawler()
+# asyncio.run(crawler.run(date=datetime.date(2022, 10, 26)))
+# print_meals(crawler.meals)


### PR DESCRIPTION
fixes #16 

# Major Changes
- 생협 크롤링 로직 수정

# Minor Changes
- 220동 운영시간이 메뉴로 표시되던 것 수정
- 자하연 식당 이름 `3층교직메뉴`로 통일
