### PR TITLE
fix: 220동 메뉴이름 수정

### DIFF
--- a/crawlers/base_crawler.py
+++ b/crawlers/base_crawler.py
@@ -146,6 +146,9 @@ class RestaurantCrawler(metaclass=ABCMeta):
         "점심",
         "저녁",
         "배식시간",
+        "평일",
+        "토요일",
+        "TakeOut",
     ]
 
     def __init__(self):

--- a/crawlers/snuco_crawler.py
+++ b/crawlers/snuco_crawler.py
@@ -181,12 +181,9 @@ class SnucoRestaurantCrawler(RestaurantCrawler):
                     meal = self.normalize(meal)
                     # is_meal_name에서 normalizer도 호출한다.
                     if self.is_meal_name(meal.name):
-                        # 220동 이름 오류 수정
+                        # ISSUE#54 220동 이름 오류 수정
                         # ex) ㅁ 바비든든( ~ ): 덮밥류 -> 바비든든: 덮밥류
-                        # ex) (평일)08:30~19:30 -> 삭제되어야 함
                         if meal.restaurant == "220동식당":
-                            if meal.name.startswith("(평일") or meal.name.startswith("(토요일"):
-                                continue
                             name_cleaned = meal.name
                             for to_clean in ["ㅁ ", "( ~ )", "(~)"]:
                                 name_cleaned = name_cleaned.replace(to_clean, "")

--- a/handler.py
+++ b/handler.py
@@ -224,6 +224,7 @@ def crawl(event, context):
         crawled_meals = []
         for crawler in crawlers:
             crawled_meals = crawled_meals + crawler.meals
+
         today = datetime.datetime.now(timezone("Asia/Seoul")).date()
         crawled_meals = list(filter(lambda meal: meal.date >= today, crawled_meals))
         restaurants_transaction(crawled_meals, cursor)


### PR DESCRIPTION
<img width="783" alt="image" src="https://github.com/wafflestudio/siksha-crawler/assets/56102267/a8bb0eca-456c-4d90-b6ec-9a103e4bec6a">


## 🍣 변경 내용

```
ㅁ [채식] 베지퀸( ~ ): 덮밥, 샌드위치, 샐러드
ㅁ 바비든든( ~ ): 덮밥류
(평일) 08:30 ~ 19:30
```

- 맨 앞에 `ㅁ ` 제거

- 가격이 범위라 FindPrice가 제대로 동작 안해서 `( ~ )`가 남아있음. 220동 한정 예외적인 상황이라 FindPrice normalize를 변경하지 않고 Snuco 크롤러 단에서 처리.

- code normalizer에 `ㅁ` 와 `~` 추가

- 평일과 토요일로 시작하는 메뉴는 여태까지 없었음을 확인, `(평일`, `(토요일` 로 시작하면 무시.


## 🍣 변경 예정 (DB)

```
ㅁ채식베지퀸~덮밥샌드위치샐러드 -> 채식베지퀸덮밥샌드위치샐러드
ㅁ바비든든~덮밥류 -> 바비든든덮밥류
ㅁ경성돈카츠~왕돈카츠통등심카츠치킨커리 -> 경성돈카츠왕돈카츠통등심카츠치킨커리
ㅁ포포420~쌀국수 -> 포포420쌀국수
ㅁ카페커피및베이커리류 -> 카페커피및베이커리류
ㅁ폭풍분식~떡볶이라면치킨 -> 폭풍분식떡볶이라면치킨
```
- 기존 menu.code와 compatible 해야하므로 (리뷰 수합할 때 필요함) DB에서 위 내용 직접 변경할 예정 ( `UPDATE menu SET code={위 내용} WHERE code LIKE '%{위 내용}%'` )



