### PR TITLE
fix: 학생회관 채식 마크 대응

### DIFF
--- a/crawlers/base_crawler.py
+++ b/crawlers/base_crawler.py
@@ -118,8 +118,9 @@ class FindPrice(MealNormalizer):
 
 class FindParenthesisHash(MealNormalizer):
     def normalize(self, meal, **kwargs):
-        if "(#)" in meal.name or "< 채식뷔페 >:" in meal.name:
-            meal.set_name(meal.name.replace("(#)", ""))
+        # 학생회관 no-meat 메뉴 마크: (#), [#]
+        if "(#)" in meal.name or "[#]" in meal.name or "< 채식뷔페 >:" in meal.name:
+            meal.set_name(meal.name.replace("(#)", "").replace("[#]", ""))
             meal.etc.append("No meat")
         return meal
 


### PR DESCRIPTION
학생회관에 (#) 외에도 [#]가 채식 마크로 추가되었습니다.
https://wafflestudio.slack.com/archives/C01L208ELKT/p1705374220110919