### PR TITLE
fix: 더이상 ths내 type 존재 않음

### DIFF
--- a/crawlers/base_crawler.py
+++ b/crawlers/base_crawler.py
@@ -42,7 +42,19 @@ class Meal:
     BR = "BR"
     LU = "LU"
     DN = "DN"
-    type_handler = {BR: BR, LU: LU, DN: DN, "아침": BR, "점심": LU, "저녁": DN, "중식": LU, "석식": DN}
+    type_handler = {
+        BR: BR,
+        LU: LU,
+        DN: DN,
+        "아침": BR,
+        "점심": LU,
+        "저녁": DN,
+        "중식": LU,
+        "석식": DN,
+        "breakfast": BR,
+        "lunch": LU,
+        "dinner": DN,
+    }
 
     def __init__(self, restaurant="", name="", date=None, type="", price=None, etc=None):
         self.set_restaurant(restaurant)


### PR DESCRIPTION
🍣 변경 사항

- meal type 표기 위치가 th 태그에서 빠진 것으로 판단됨. 이제는 tr 내 td의 class에 "breakfast", "lunch", "dinner" 가 표시되길래 이를 활용했음. 다만 이전에 th와 td에 중복하여 type 정보가 있었는지, 아니면 이번에 th에서 빠지면서 td로 저기로 이동한건지는 모르겠음.
- 참고로 td.breakfast를 파고 들어가면 "아침" 이라는 토큰을 얻을 수 있을 것 같긴 한데, 공시적으로 class 명을 breakfast, lunch, dinner로 쓰고있는 만큼 굳이 그럴 이유는 없다고 생각했슴니다.