### PR TITLE
fix: 크롤링 실패 시 slack으로 에러메시지 전송

### DIFF
--- a/crawlers/base_crawler.py
+++ b/crawlers/base_crawler.py
@@ -259,15 +259,14 @@ class RestaurantCrawler(metaclass=ABCMeta):
             ) as session:
                 async with session.get(url) as response:
                     if response.status != 200:
-                        print(f"Failed to fetch {url}: Status code {response.status}")
+                        _send_slack_message(f"Failed to fetch {url}: Status code {response.status}")
                         return
                     html = await response.read()
                     # html = await response.text()
                     soup = BeautifulSoup(html, "html.parser")
                     self.crawl(soup, **kwargs)
         except Exception as e:
-            print(f"Error in Run: {str(e)}")
-            print(f"URL: {url}")
+            _send_slack_message(f"Error in Run, {type(e).__name}: {str(e)}\nURL: {url}")
 
     def normalize(self, meal, **kwargs):
         for normalizer_cls in self.normalizer_classes:

--- a/slack.py
+++ b/slack.py
@@ -5,9 +5,9 @@ import requests
 
 def _send_slack_message(message: str):
     slack_token = os.environ.get("SLACK_TOKEN")
-    slack_channel = os.environ["SLACK_CHANNEL"]
+    slack_channel = os.environ.get("SLACK_CHANNEL")
     if not slack_token:
-        print("No Slack token provided. Skipping sending message.")
+        print(f"No Slack token provided. Skip sending message: {message}")
         return
     body = {"channel": slack_channel, "text": message}
     headers = {"Authorization": f"Bearer {slack_token}"}


### PR DESCRIPTION
# Pull Request

## 설명

월요일 새벽마다 크롤링이 실패하고 있는데, 해당 문제가 다른 시간대에는 발생하지 않고 재현이 어려워 디버깅에 난항을 겪고 있습니다. 또한 cron job 특성상 로그도 남지 않고 있습니다.
크롤링 실패 시 조금 더 구체적인 에러 메시지를 slack으로 전송하도록 수정하여 원인파악을 하고자 합니다.

## 어떤 종류의 PR인가요?

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## 테스트는 어떤 방식으로 진행하셨나요?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Unit Test with pytest
- [ ] Integration Test with pytest
- [ ] Manual Test

## 체크리스트

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in **hard-to-understand areas**
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules