### PR TITLE
fix: apply lowercase to code field

### DIFF
--- a/crawlers/base_crawler.py
+++ b/crawlers/base_crawler.py
@@ -16,7 +16,7 @@ def text_normalizer(text, convert_to_code=False):
     text = re.sub(r"\xa0", " ", text)
     if convert_to_code:
         # remove special characters and make lowercase
-        text = re.sub(r"[^a-zA-Z가-힣0-9]+", "", text)
+        text = re.sub(r"[^a-zA-Z가-힣0-9一-龯]+", "", text)
         text = text.lower()
     return text
 

--- a/crawlers/base_crawler.py
+++ b/crawlers/base_crawler.py
@@ -11,33 +11,13 @@ from pytz import timezone
 from slack import _send_slack_message
 
 
-def text_normalizer(text, only_letters=False):
-    non_letters = [
-        r"\s",
-        "<",
-        ">",
-        r"\(",
-        r"\)",
-        r"\[",
-        r"\]",
-        ",",
-        r"\*",
-        "&",
-        r"\+",
-        "-",
-        r"/",
-        ":",
-        "#",
-        r"\.",
-        "♣",
-        "▷",
-        "ㅁ",
-        "~",
-    ]
+def text_normalizer(text, convert_to_code=False):
     text = re.sub(r"\n|\(\)|<>", "", text).strip().strip(":")
     text = re.sub(r"\xa0", " ", text)
-    if only_letters:
-        text = re.sub("|".join(non_letters), "", text)
+    if convert_to_code:
+        # remove special characters and make lowercase
+        text = re.sub(r"[^a-zA-Z가-힣0-9]+", "", text)
+        text = text.lower()
     return text
 
 


### PR DESCRIPTION
# Pull Request

## 설명

https://wafflestudio.slack.com/archives/C01UUJEBMNY/p1752487454294739
---
**원인**

`{'date': datetime.date(2025, 7, 16), 'type': 'DN', 'price': 6500, 'etc': '[]', 'restaurant_id': 183, 'name_kr': '<셀프코너>: 잡곡밥+돈육순두부찌개+블랙알리오찜닭+생선까스*타르s+오복채무침+미니뱅오쇼콜라+포기김치+그린샐러드', 'code': '셀프코너잡곡밥돈육순두부찌개블랙알리오찜닭생선까스타르s오복채무침미니뱅오쇼콜라포기김치그린샐러드'}`

`{'date': datetime.date(2025, 7, 16), 'type': 'DN', 'price': 6500, 'etc': '[]', 'restaurant_id': 183, 'name_kr': '<셀프코너>: 잡곡밥+돈육순두부찌개+블랙알리오찜닭+생선까스*타르S+오복채무침+미니뱅오쇼콜라+포기김치+그린샐러드', 'code': '셀프코너잡곡밥돈육순두부찌개블랙알리오찜닭생선까스타르S오복채무침미니뱅오쇼콜라포기김치그린샐러드'}`

생협 홈페이지 내 중복 메뉴가 올라와있는 상황에서, 크롤러 내 중복을 처리하는 로직이 있으나 대소문자를 구분함

그러나 DBMS의 collation은 `utf8mb4_unicode_ci` 를 사용 -> **대소문자를 구분하지 않음**
즉,  _타르s_ 와 _타르S_ 가 크롤러 내부적으로는 unique하지만 DB입장에서는 unique하지 않은 것으로 취급되어 Duplicate entry 오류가 발생하고 있었습니다.

---
**해결**

따라서 code field 생성 시 lowercase로 바꾸게 수정하였습니다.
번외로 특수문자를 일부만 지워주고 있어 모두 지우도록 수정하였습니다.
기존 DB에는 code 내 특수문자가 일부 포함된 경우가 있으므로, prod에서 크롤러 실행 전 DB작업이 필요합니다.
ex) `????뷔페????태국식코코넛밀크새우커리사천식제육강정연근조림무말랭이무침열무된장국그린샐러드오늘의차`, `▶NEW계절한정메뉴삼계탕`


## 어떤 종류의 PR인가요?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update